### PR TITLE
Assert that all suffixes and standard abbrevs are included in the abbreviations list

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,15 @@ const street_types = require('street-types');
  * @return Object              - map of abbreviations to suffixes
  */
 function flatten( types, key ) {
-  return types.reduce( ( prev, type ) => {
+  return types
+  .map( type => {
+    const abbrs = new Set( type.abbrs )
+    .add( type.suffix )
+    .add( type.standardAbbr );
+
+    return Object.assign( {}, type, { abbrs: [ ...abbrs ] } );
+  })
+  .reduce( ( prev, type ) => {
     return type.abbrs.reduce( ( flat, abbr ) => {
       return Object.assign( flat, { [ abbr.trim() ]: type[ key ] } );
     }, prev );

--- a/test.js
+++ b/test.js
@@ -12,19 +12,24 @@ describe( 'index', () => {
       const flatten = module.__get__('flatten');
       const given = [
         {
-          "suffix": "ALLEY",
-          "abbrs": ["ALLEE", "ALLEY", "ALLY", "ALY"],
-          "standardAbbr": "ALY"
+          'suffix': 'ALLEY',
+          'abbrs': [ 'ALLEE', 'ALLEY', 'ALLY', 'ALY' ],
+          'standardAbbr': 'ALY'
         },
         {
-          "suffix": "ANEX",
-          "abbrs": ["ANEX", "ANNEX", "ANNX", "ANX"],
-          "standardAbbr": "ANX"
+          'suffix': 'ANEX',
+          'abbrs': [ 'ANEX', 'ANNEX', 'ANNX', 'ANX' ],
+          'standardAbbr': 'ANX'
         },
         {
-          "suffix": "ARCADE",
-          "abbrs": ["ARC", "ARCADE "],
-          "standardAbbr": "ARC"
+          'suffix': 'ARCADE',
+          'abbrs': [ 'ARC', 'ARCADE ' ],
+          'standardAbbr': 'ARC'
+        },
+        {
+          'suffix': 'PLACE',
+          'abbrs': ['PL'],
+          'standardAbbr': 'PL'
         }
       ];
 
@@ -40,7 +45,9 @@ describe( 'index', () => {
         ANNX: 'ANEX',
         ANX: 'ANEX',
         ARC: 'ARCADE',
-        ARCADE: 'ARCADE'
+        ARCADE: 'ARCADE',
+        PLACE: 'PLACE',
+        PL: 'PLACE',
       };
 
       assert.deepEqual( actual, expected );


### PR DESCRIPTION
Some of the `street-types` data isn't entirely 1:1 and it causes downstream problems when you try to go back and forth. 

This change should fix that.